### PR TITLE
remove overlapping (as of MonadRandom >= 0.5) instance for MonadError; fix #5

### DIFF
--- a/luck/luck.cabal
+++ b/luck/luck.cabal
@@ -42,7 +42,7 @@ library
   hs-source-dirs:      src
   build-depends:       base >=4.7 && <5.0, pretty >=1.1 && <1.2, cmdargs, word8,
                        utf8-string, bytestring, mtl >= 2.2.1, array,
-                       containers, QuickCheck >= 2.7, random, MonadRandom,
+                       containers, QuickCheck >= 2.7, random, MonadRandom >= 0.5,
                        rosezipper >= 0.1, lens >= 4.9.1, template-haskell, 
                        transformers, filepath
 

--- a/luck/src/Core/Semantics.hs
+++ b/luck/src/Core/Semantics.hs
@@ -88,10 +88,6 @@ liftCatch' :: Monad m => Catch e m (a,s) -> Catch e (RandT s m) a
 liftCatch' catchE m h =
     liftRandT $ \ s -> runRandT m s `catchE` \ e -> runRandT (h e) s
 
-instance MonadError e m => MonadError e (RandT StdGen m) where
-    throwError = lift . throwError
-    catchError = liftCatch' catchError
-
 unsat :: String -> Luck a
 unsat msg = do 
   s <- get 


### PR DESCRIPTION
…; require MonadRandom >= 0.5 in cabal-file